### PR TITLE
HT-6757: Convert some `aws_security_group_rule` to use `for_each`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -557,7 +557,7 @@ resource "aws_security_group_rule" "computed_egress_with_source_security_group_i
 
 # Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "egress_with_cidr_blocks" {
-  for_each = module.this.enabled ? var.egress_with_cidr_blocks : []
+  count = module.this.enabled ? length(var.egress_with_cidr_blocks) : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
@@ -565,32 +565,32 @@ resource "aws_security_group_rule" "egress_with_cidr_blocks" {
   cidr_blocks = split(
     ",",
     lookup(
-      each.value,
+      var.egress_with_cidr_blocks[count.index],
       "cidr_blocks",
       join(",", var.egress_cidr_blocks),
     ),
   )
   prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
-    each.value,
+    var.egress_with_cidr_blocks[count.index],
     "description",
     "Egress Rule",
   )
 
   from_port = lookup(
-    each.value,
+    var.egress_with_cidr_blocks[count.index],
     "from_port",
-    var.rules[lookup(each.value, "rule", "_")][0],
+    var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")][0],
   )
   to_port = lookup(
-    each.value,
+    var.egress_with_cidr_blocks[count.index],
     "to_port",
-    var.rules[lookup(each.value, "rule", "_")][1],
+    var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")][1],
   )
   protocol = lookup(
-    each.value,
+    var.egress_with_cidr_blocks[count.index],
     "protocol",
-    var.rules[lookup(each.value, "rule", "_")][2],
+    var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -271,7 +271,7 @@ resource "aws_security_group_rule" "computed_ingress_with_cidr_blocks" {
 
 # Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
-  count = module.this.enabled ? length(var.ingress_with_ipv6_cidr_blocks) : 0
+  for_each = module.this.enabled ? var.ingress_with_ipv6_cidr_blocks : []
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -279,32 +279,32 @@ resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
   ipv6_cidr_blocks = split(
     ",",
     lookup(
-      var.ingress_with_ipv6_cidr_blocks[count.index],
+      each.value,
       "ipv6_cidr_blocks",
       join(",", var.ingress_ipv6_cidr_blocks),
     ),
   )
   prefix_list_ids = var.ingress_prefix_list_ids
   description = lookup(
-    var.ingress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "description",
     "Ingress Rule",
   )
 
   from_port = lookup(
-    var.ingress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "from_port",
-    var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")][0],
+    var.rules[lookup(each.value, "rule", "_")][0],
   )
   to_port = lookup(
-    var.ingress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "to_port",
-    var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")][1],
+    var.rules[lookup(each.value, "rule", "_")][1],
   )
   protocol = lookup(
-    var.ingress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "protocol",
-    var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")][2],
+    var.rules[lookup(each.value, "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_security_group" "this_name_prefix" {
 ###################################
 # Security group rules with "cidr_blocks" and it uses list of rules names
 resource "aws_security_group_rule" "ingress_rules" {
-  count = module.this.enabled ? length(var.ingress_rules) : 0
+  for_each = module.this.enabled ? toset(var.ingress_rules) : []
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -64,11 +64,11 @@ resource "aws_security_group_rule" "ingress_rules" {
   cidr_blocks      = var.ingress_cidr_blocks
   ipv6_cidr_blocks = var.ingress_ipv6_cidr_blocks
   prefix_list_ids  = var.ingress_prefix_list_ids
-  description      = var.rules[var.ingress_rules[count.index]][3]
+  description      = var.rules[each.value][3]
 
-  from_port = var.rules[var.ingress_rules[count.index]][0]
-  to_port   = var.rules[var.ingress_rules[count.index]][1]
-  protocol  = var.rules[var.ingress_rules[count.index]][2]
+  from_port = var.rules[each.value][0]
+  to_port   = var.rules[each.value][1]
+  protocol  = var.rules[each.value][2]
 }
 
 # Computed - Security group rules with "cidr_blocks" and it uses list of rules names

--- a/main.tf
+++ b/main.tf
@@ -469,7 +469,7 @@ resource "aws_security_group_rule" "computed_egress_rules" {
 #########################
 # Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
 resource "aws_security_group_rule" "egress_with_source_security_group_id" {
-  for_each = module.this.enabled ? var.egress_with_source_security_group_id : []
+  for_each = { for rule in var.egress_with_source_security_group_id : rule.source_security_group_id => rule }
 
   security_group_id = local.this_sg_id
   type              = "egress"

--- a/main.tf
+++ b/main.tf
@@ -271,7 +271,7 @@ resource "aws_security_group_rule" "computed_ingress_with_cidr_blocks" {
 
 # Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
-  for_each = module.this.enabled ? var.ingress_with_ipv6_cidr_blocks : []
+  count = module.this.enabled ? length(var.ingress_with_ipv6_cidr_blocks) : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -279,32 +279,32 @@ resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
   ipv6_cidr_blocks = split(
     ",",
     lookup(
-      each.value,
+      var.ingress_with_ipv6_cidr_blocks[count.index],
       "ipv6_cidr_blocks",
       join(",", var.ingress_ipv6_cidr_blocks),
     ),
   )
   prefix_list_ids = var.ingress_prefix_list_ids
   description = lookup(
-    each.value,
+    var.ingress_with_ipv6_cidr_blocks[count.index],
     "description",
     "Ingress Rule",
   )
 
   from_port = lookup(
-    each.value,
+    var.ingress_with_ipv6_cidr_blocks[count.index],
     "from_port",
-    var.rules[lookup(each.value, "rule", "_")][0],
+    var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")][0],
   )
   to_port = lookup(
-    each.value,
+    var.ingress_with_ipv6_cidr_blocks[count.index],
     "to_port",
-    var.rules[lookup(each.value, "rule", "_")][1],
+    var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")][1],
   )
   protocol = lookup(
-    each.value,
+    var.ingress_with_ipv6_cidr_blocks[count.index],
     "protocol",
-    var.rules[lookup(each.value, "rule", "_")][2],
+    var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -93,42 +93,42 @@ resource "aws_security_group_rule" "computed_ingress_rules" {
 ##########################
 # Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
 resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
-  count = module.this.enabled ? length(var.ingress_with_source_security_group_id) : 0
+  for_each = module.this.enabled ? var.ingress_with_source_security_group_id : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
 
-  source_security_group_id = var.ingress_with_source_security_group_id[count.index]["source_security_group_id"]
+  source_security_group_id = each.value["source_security_group_id"]
   prefix_list_ids          = var.ingress_prefix_list_ids
   description = lookup(
-    var.ingress_with_source_security_group_id[count.index],
+    each.value,
     "description",
     "Ingress Rule",
   )
 
   from_port = lookup(
-    var.ingress_with_source_security_group_id[count.index],
+    each.value,
     "from_port",
     var.rules[lookup(
-      var.ingress_with_source_security_group_id[count.index],
+      each.value,
       "rule",
       "_",
     )][0],
   )
   to_port = lookup(
-    var.ingress_with_source_security_group_id[count.index],
+    each.value,
     "to_port",
     var.rules[lookup(
-      var.ingress_with_source_security_group_id[count.index],
+      each.value,
       "rule",
       "_",
     )][1],
   )
   protocol = lookup(
-    var.ingress_with_source_security_group_id[count.index],
+    each.value,
     "protocol",
     var.rules[lookup(
-      var.ingress_with_source_security_group_id[count.index],
+      each.value,
       "rule",
       "_",
     )][2],
@@ -181,7 +181,8 @@ resource "aws_security_group_rule" "computed_ingress_with_source_security_group_
 
 # Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
-  count = module.this.enabled ? length(var.ingress_with_cidr_blocks) : 0
+  count    = module.this.enabled ? length(var.ingress_with_cidr_blocks) : 0
+  for_each = module.this.enabled ? var.ingress_with_cidr_blocks : []
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -189,32 +190,32 @@ resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
   cidr_blocks = split(
     ",",
     lookup(
-      var.ingress_with_cidr_blocks[count.index],
+      each.value,
       "cidr_blocks",
       join(",", var.ingress_cidr_blocks),
     ),
   )
   prefix_list_ids = var.ingress_prefix_list_ids
   description = lookup(
-    var.ingress_with_cidr_blocks[count.index],
+    each.value,
     "description",
     "Ingress Rule",
   )
 
   from_port = lookup(
-    var.ingress_with_cidr_blocks[count.index],
+    each.value,
     "from_port",
-    var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")][0],
+    var.rules[lookup(each.value, "rule", "_")][0],
   )
   to_port = lookup(
-    var.ingress_with_cidr_blocks[count.index],
+    each.value,
     "to_port",
-    var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")][1],
+    var.rules[lookup(each.value, "rule", "_")][1],
   )
   protocol = lookup(
-    var.ingress_with_cidr_blocks[count.index],
+    each.value,
     "protocol",
-    var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")][2],
+    var.rules[lookup(each.value, "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -361,33 +361,33 @@ resource "aws_security_group_rule" "computed_ingress_with_ipv6_cidr_blocks" {
 
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
 resource "aws_security_group_rule" "ingress_with_self" {
-  for_each = module.this.enabled ? var.ingress_with_self : []
+  count = module.this.enabled ? length(var.ingress_with_self) : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
 
-  self            = lookup(each.value, "self", true)
+  self            = lookup(var.ingress_with_self[count.index], "self", true)
   prefix_list_ids = var.ingress_prefix_list_ids
   description = lookup(
-    each.value,
+    var.ingress_with_self[count.index],
     "description",
     "Ingress Rule",
   )
 
   from_port = lookup(
-    each.value,
+    var.ingress_with_self[count.index],
     "from_port",
-    var.rules[lookup(each.value, "rule", "_")][0],
+    var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")][0],
   )
   to_port = lookup(
-    each.value,
+    var.ingress_with_self[count.index],
     "to_port",
-    var.rules[lookup(each.value, "rule", "_")][1],
+    var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")][1],
   )
   protocol = lookup(
-    each.value,
+    var.ingress_with_self[count.index],
     "protocol",
-    var.rules[lookup(each.value, "rule", "_")][2],
+    var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,6 @@ resource "aws_security_group_rule" "computed_ingress_with_source_security_group_
 
 # Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
-  count    = module.this.enabled ? length(var.ingress_with_cidr_blocks) : 0
   for_each = module.this.enabled ? var.ingress_with_cidr_blocks : []
 
   security_group_id = local.this_sg_id

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "computed_ingress_rules" {
 ##########################
 # Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
 resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
-  for_each = module.this.enabled ? var.ingress_with_source_security_group_id : 0
+  for_each = { for rule in var.ingress_with_source_security_group_id : rule.source_security_group_id => rule }
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -181,7 +181,7 @@ resource "aws_security_group_rule" "computed_ingress_with_source_security_group_
 
 # Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
-  for_each = module.this.enabled ? var.ingress_with_cidr_blocks : []
+  count = module.this.enabled ? length(var.ingress_with_cidr_blocks) : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -189,32 +189,32 @@ resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
   cidr_blocks = split(
     ",",
     lookup(
-      each.value,
+      var.ingress_with_cidr_blocks[count.index],
       "cidr_blocks",
       join(",", var.ingress_cidr_blocks),
     ),
   )
   prefix_list_ids = var.ingress_prefix_list_ids
   description = lookup(
-    each.value,
+    var.ingress_with_cidr_blocks[count.index],
     "description",
     "Ingress Rule",
   )
 
   from_port = lookup(
-    each.value,
+    var.ingress_with_cidr_blocks[count.index],
     "from_port",
-    var.rules[lookup(each.value, "rule", "_")][0],
+    var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")][0],
   )
   to_port = lookup(
-    each.value,
+    var.ingress_with_cidr_blocks[count.index],
     "to_port",
-    var.rules[lookup(each.value, "rule", "_")][1],
+    var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")][1],
   )
   protocol = lookup(
-    each.value,
+    var.ingress_with_cidr_blocks[count.index],
     "protocol",
-    var.rules[lookup(each.value, "rule", "_")][2],
+    var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -432,7 +432,7 @@ resource "aws_security_group_rule" "computed_ingress_with_self" {
 ##################################
 # Security group rules with "cidr_blocks" and it uses list of rules names
 resource "aws_security_group_rule" "egress_rules" {
-  count = module.this.enabled ? length(var.egress_rules) : 0
+  for_each = module.this.enabled ? toset(var.egress_rules) : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
@@ -440,11 +440,11 @@ resource "aws_security_group_rule" "egress_rules" {
   cidr_blocks      = var.egress_cidr_blocks
   ipv6_cidr_blocks = var.egress_ipv6_cidr_blocks
   prefix_list_ids  = var.egress_prefix_list_ids
-  description      = var.rules[var.egress_rules[count.index]][3]
+  description      = var.rules[each.value][3]
 
-  from_port = var.rules[var.egress_rules[count.index]][0]
-  to_port   = var.rules[var.egress_rules[count.index]][1]
-  protocol  = var.rules[var.egress_rules[count.index]][2]
+  from_port = var.rules[each.value][0]
+  to_port   = var.rules[each.value][1]
+  protocol  = var.rules[each.value][2]
 }
 
 # Computed - Security group rules with "cidr_blocks" and it uses list of rules names
@@ -469,42 +469,42 @@ resource "aws_security_group_rule" "computed_egress_rules" {
 #########################
 # Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
 resource "aws_security_group_rule" "egress_with_source_security_group_id" {
-  count = module.this.enabled ? length(var.egress_with_source_security_group_id) : 0
+  for_each = module.this.enabled ? var.egress_with_source_security_group_id : []
 
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  source_security_group_id = var.egress_with_source_security_group_id[count.index]["source_security_group_id"]
+  source_security_group_id = each.value["source_security_group_id"]
   prefix_list_ids          = var.egress_prefix_list_ids
   description = lookup(
-    var.egress_with_source_security_group_id[count.index],
+    each.value,
     "description",
     "Egress Rule",
   )
 
   from_port = lookup(
-    var.egress_with_source_security_group_id[count.index],
+    each.value,
     "from_port",
     var.rules[lookup(
-      var.egress_with_source_security_group_id[count.index],
+      each.value,
       "rule",
       "_",
     )][0],
   )
   to_port = lookup(
-    var.egress_with_source_security_group_id[count.index],
+    each.value,
     "to_port",
     var.rules[lookup(
-      var.egress_with_source_security_group_id[count.index],
+      each.value,
       "rule",
       "_",
     )][1],
   )
   protocol = lookup(
-    var.egress_with_source_security_group_id[count.index],
+    each.value,
     "protocol",
     var.rules[lookup(
-      var.egress_with_source_security_group_id[count.index],
+      each.value,
       "rule",
       "_",
     )][2],
@@ -557,7 +557,7 @@ resource "aws_security_group_rule" "computed_egress_with_source_security_group_i
 
 # Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "egress_with_cidr_blocks" {
-  count = module.this.enabled ? length(var.egress_with_cidr_blocks) : 0
+  for_each = module.this.enabled ? var.egress_with_cidr_blocks : []
 
   security_group_id = local.this_sg_id
   type              = "egress"
@@ -565,32 +565,32 @@ resource "aws_security_group_rule" "egress_with_cidr_blocks" {
   cidr_blocks = split(
     ",",
     lookup(
-      var.egress_with_cidr_blocks[count.index],
+      each.value,
       "cidr_blocks",
       join(",", var.egress_cidr_blocks),
     ),
   )
   prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
-    var.egress_with_cidr_blocks[count.index],
+    each.value,
     "description",
     "Egress Rule",
   )
 
   from_port = lookup(
-    var.egress_with_cidr_blocks[count.index],
+    each.value,
     "from_port",
-    var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")][0],
+    var.rules[lookup(each.value, "rule", "_")][0],
   )
   to_port = lookup(
-    var.egress_with_cidr_blocks[count.index],
+    each.value,
     "to_port",
-    var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")][1],
+    var.rules[lookup(each.value, "rule", "_")][1],
   )
   protocol = lookup(
-    var.egress_with_cidr_blocks[count.index],
+    each.value,
     "protocol",
-    var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")][2],
+    var.rules[lookup(each.value, "rule", "_")][2],
   )
 }
 
@@ -647,7 +647,7 @@ resource "aws_security_group_rule" "computed_egress_with_cidr_blocks" {
 
 # Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
-  count = module.this.enabled ? length(var.egress_with_ipv6_cidr_blocks) : 0
+  for_each = module.this.enabled ? var.egress_with_ipv6_cidr_blocks : []
 
   security_group_id = local.this_sg_id
   type              = "egress"
@@ -655,32 +655,32 @@ resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
   ipv6_cidr_blocks = split(
     ",",
     lookup(
-      var.egress_with_ipv6_cidr_blocks[count.index],
+      each.value,
       "ipv6_cidr_blocks",
       join(",", var.egress_ipv6_cidr_blocks),
     ),
   )
   prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
-    var.egress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "description",
     "Egress Rule",
   )
 
   from_port = lookup(
-    var.egress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "from_port",
-    var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")][0],
+    var.rules[lookup(each.value, "rule", "_")][0],
   )
   to_port = lookup(
-    var.egress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "to_port",
-    var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")][1],
+    var.rules[lookup(each.value, "rule", "_")][1],
   )
   protocol = lookup(
-    var.egress_with_ipv6_cidr_blocks[count.index],
+    each.value,
     "protocol",
-    var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")][2],
+    var.rules[lookup(each.value, "rule", "_")][2],
   )
 }
 
@@ -737,33 +737,33 @@ resource "aws_security_group_rule" "computed_egress_with_ipv6_cidr_blocks" {
 
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
 resource "aws_security_group_rule" "egress_with_self" {
-  count = module.this.enabled ? length(var.egress_with_self) : 0
+  for_each = module.this.enabled ? var.engress_with_self : []
 
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  self            = lookup(var.egress_with_self[count.index], "self", true)
+  self            = lookup(each.value, "self", true)
   prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
-    var.egress_with_self[count.index],
+    each.value,
     "description",
     "Egress Rule",
   )
 
   from_port = lookup(
-    var.egress_with_self[count.index],
+    each.value,
     "from_port",
-    var.rules[lookup(var.egress_with_self[count.index], "rule", "_")][0],
+    var.rules[lookup(each.value, "rule", "_")][0],
   )
   to_port = lookup(
-    var.egress_with_self[count.index],
+    each.value,
     "to_port",
-    var.rules[lookup(var.egress_with_self[count.index], "rule", "_")][1],
+    var.rules[lookup(each.value, "rule", "_")][1],
   )
   protocol = lookup(
-    var.egress_with_self[count.index],
+    each.value,
     "protocol",
-    var.rules[lookup(var.egress_with_self[count.index], "rule", "_")][2],
+    var.rules[lookup(each.value, "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -361,33 +361,33 @@ resource "aws_security_group_rule" "computed_ingress_with_ipv6_cidr_blocks" {
 
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
 resource "aws_security_group_rule" "ingress_with_self" {
-  count = module.this.enabled ? length(var.ingress_with_self) : 0
+  for_each = module.this.enabled ? var.ingress_with_self : []
 
   security_group_id = local.this_sg_id
   type              = "ingress"
 
-  self            = lookup(var.ingress_with_self[count.index], "self", true)
+  self            = lookup(each.value, "self", true)
   prefix_list_ids = var.ingress_prefix_list_ids
   description = lookup(
-    var.ingress_with_self[count.index],
+    each.value,
     "description",
     "Ingress Rule",
   )
 
   from_port = lookup(
-    var.ingress_with_self[count.index],
+    each.value,
     "from_port",
-    var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")][0],
+    var.rules[lookup(each.value, "rule", "_")][0],
   )
   to_port = lookup(
-    var.ingress_with_self[count.index],
+    each.value,
     "to_port",
-    var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")][1],
+    var.rules[lookup(each.value, "rule", "_")][1],
   )
   protocol = lookup(
-    var.ingress_with_self[count.index],
+    each.value,
     "protocol",
-    var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")][2],
+    var.rules[lookup(each.value, "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -737,33 +737,33 @@ resource "aws_security_group_rule" "computed_egress_with_ipv6_cidr_blocks" {
 
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
 resource "aws_security_group_rule" "egress_with_self" {
-  for_each = module.this.enabled ? var.engress_with_self : []
+  count = module.this.enabled ? length(var.egress_with_self) : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  self            = lookup(each.value, "self", true)
+  self            = lookup(var.egress_with_self[count.index], "self", true)
   prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
-    each.value,
+    var.egress_with_self[count.index],
     "description",
     "Egress Rule",
   )
 
   from_port = lookup(
-    each.value,
+    var.egress_with_self[count.index],
     "from_port",
-    var.rules[lookup(each.value, "rule", "_")][0],
+    var.rules[lookup(var.egress_with_self[count.index], "rule", "_")][0],
   )
   to_port = lookup(
-    each.value,
+    var.egress_with_self[count.index],
     "to_port",
-    var.rules[lookup(each.value, "rule", "_")][1],
+    var.rules[lookup(var.egress_with_self[count.index], "rule", "_")][1],
   )
   protocol = lookup(
-    each.value,
+    var.egress_with_self[count.index],
     "protocol",
-    var.rules[lookup(each.value, "rule", "_")][2],
+    var.rules[lookup(var.egress_with_self[count.index], "rule", "_")][2],
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -647,7 +647,7 @@ resource "aws_security_group_rule" "computed_egress_with_cidr_blocks" {
 
 # Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
-  for_each = module.this.enabled ? var.egress_with_ipv6_cidr_blocks : []
+  count = module.this.enabled ? length(var.egress_with_ipv6_cidr_blocks) : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
@@ -655,32 +655,32 @@ resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
   ipv6_cidr_blocks = split(
     ",",
     lookup(
-      each.value,
+      var.egress_with_ipv6_cidr_blocks[count.index],
       "ipv6_cidr_blocks",
       join(",", var.egress_ipv6_cidr_blocks),
     ),
   )
   prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
-    each.value,
+    var.egress_with_ipv6_cidr_blocks[count.index],
     "description",
     "Egress Rule",
   )
 
   from_port = lookup(
-    each.value,
+    var.egress_with_ipv6_cidr_blocks[count.index],
     "from_port",
-    var.rules[lookup(each.value, "rule", "_")][0],
+    var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")][0],
   )
   to_port = lookup(
-    each.value,
+    var.egress_with_ipv6_cidr_blocks[count.index],
     "to_port",
-    var.rules[lookup(each.value, "rule", "_")][1],
+    var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")][1],
   )
   protocol = lookup(
-    each.value,
+    var.egress_with_ipv6_cidr_blocks[count.index],
     "protocol",
-    var.rules[lookup(each.value, "rule", "_")][2],
+    var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")][2],
   )
 }
 


### PR DESCRIPTION
## Jira
[Ticket.](https://humnai.atlassian.net/browse/HT-6757)
## Description
This module used to depend heavily on the use of the `count` meta-argument. Removing SG rules therefore caused churn.
## Changes
Convert - where sensible - `aws_security_group_rules` to use the `for_each` meta-argument.
## Notes
The documentation for the `for_each` meta-argument ([ref](https://www.terraform.io/language/meta-arguments/for_each)) states:
> The for_each meta-argument accepts a map or a set of strings [...]
This means that some of the `aws_security_group_rules` blocks were impractical to convert to using the `for_each` block.